### PR TITLE
Cancel replaced timeouts to avoid leak

### DIFF
--- a/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
+++ b/client/src/main/java/org/asynchttpclient/netty/NettyResponseFuture.java
@@ -366,7 +366,10 @@ public final class NettyResponseFuture<V> implements ListenableFuture<V> {
   }
 
   public void setTimeoutsHolder(TimeoutsHolder timeoutsHolder) {
-    TIMEOUTS_HOLDER_FIELD.set(this, timeoutsHolder);
+    TimeoutsHolder ref = TIMEOUTS_HOLDER_FIELD.getAndSet(this, timeoutsHolder);
+    if (ref != null) {
+      ref.cancel();
+    }
   }
 
   public boolean isInAuth() {


### PR DESCRIPTION
When setting the TimeoutHolder, cancel any prior timeout so that they don't leak. 

Previously, they would just be lost and remain in the timer until their timeout expired, which could be a long time. Previously, encountering a redirect would trigger this code, causing the old request timer to be replaced with a new one. The old timer would maintain a link back to this Future, but couldn't be canceled by this future (as its reference had been overwritten) causing the Future, is associated Response, and any AsyncResponseHandler to be retained in memory instead of being garbage collected once the request had been processed.

Fixes AsyncHttpClient/async-http-client#1731